### PR TITLE
fix(capture-pipeline): add LAUNCHER intent-filter (v1.0.1)

### DIFF
--- a/apps/capture-pipeline/android/app/src/main/AndroidManifest.xml
+++ b/apps/capture-pipeline/android/app/src/main/AndroidManifest.xml
@@ -9,7 +9,7 @@
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
 
-        <!-- Main Activity (Hidden from launcher) -->
+        <!-- Main Activity -->
         <activity
             android:name=".MainActivity"
             android:exported="true"
@@ -18,14 +18,20 @@
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
             android:windowSoftInputMode="adjustResize">
-            
+
+            <!-- Launcher Intent Filter (앱 서랍에 표시) -->
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+
             <!-- Share Intent Filter -->
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="text/plain" />
             </intent-filter>
-            
+
             <meta-data
                 android:name="io.flutter.embedding.android.NormalTheme"
                 android:resource="@style/NormalTheme" />

--- a/apps/capture-pipeline/app-meta.json
+++ b/apps/capture-pipeline/app-meta.json
@@ -2,7 +2,7 @@
   "id": "capture-pipeline",
   "name": "Capture Pipeline",
   "desc": "공유 텍스트 캡처 & 아카이빙",
-  "version": "v1.0.0",
+  "version": "v1.0.1",
   "icon": "📥",
   "cardClass": "capture",
   "workflow": "build-capture-pipeline"

--- a/apps/capture-pipeline/pubspec.yaml
+++ b/apps/capture-pipeline/pubspec.yaml
@@ -1,7 +1,7 @@
 name: capture_pipeline
 description: Personal text capture pipeline - Share to Local & GitHub
 publish_to: 'none'
-version: 1.0.0+1
+version: 1.0.1+2
 
 environment:
   sdk: '>=3.0.0 <4.0.0'

--- a/dashboard/apps.json
+++ b/dashboard/apps.json
@@ -23,7 +23,7 @@
     "id": "capture-pipeline",
     "name": "Capture Pipeline",
     "desc": "공유 텍스트 캡처 & 아카이빙",
-    "version": "v1.0.0",
+    "version": "v1.0.1",
     "icon": "📥",
     "cardClass": "capture",
     "workflow": "build-capture-pipeline",

--- a/dashboard/sw.js
+++ b/dashboard/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'apk-store-v4';
+const CACHE_NAME = 'apk-store-v5';
 const ASSETS = [
     './',
     './index.html',


### PR DESCRIPTION
Problem: App installed but didn't appear in app drawer
Cause: Missing LAUNCHER intent-filter in AndroidManifest.xml

Fix: Added MAIN/LAUNCHER intent-filter so app shows in launcher
- Keep existing SEND intent-filter for Share functionality
- Version bump to v1.0.1+2
- Dashboard cache v5